### PR TITLE
Refactor datapackage naming

### DIFF
--- a/src/opendatapy/datapackage.py
+++ b/src/opendatapy/datapackage.py
@@ -179,7 +179,7 @@ def load_resource(
                 ]
 
             # Copy metaschema to resource schema if specified
-            if resource_json["schema"] == "metaschema":
+            if resource_json["schema"] == "inherit-from-format":
                 # Copy metaschema to schema
                 resource_json["schema"] = resource_json["metaschema"]
                 # Label schema as metaschema copy so we don't overwrite it

--- a/src/opendatapy/datapackage.py
+++ b/src/opendatapy/datapackage.py
@@ -11,9 +11,9 @@ from .resources import TabularDataResource
 
 DEFAULT_BASE_PATH = os.getcwd()  # Default base datapackage path
 ALGORITHMS_DIR = "algorithms"
-ARGUMENTS_DIR = "arguments"
+CONFIGURATIONS_DIR = "configurations"
 RESOURCES_DIR = "resources"
-METASCHEMAS_DIR = "metaschemas"
+FORMATS_DIR = "formats"
 VIEWS_DIR = "views"
 
 
@@ -31,22 +31,20 @@ class ResourceError(Exception):
 
 def execute_datapackage(
     docker_client: DockerClient,
-    algorithm_name: str,
-    argument_space_name: str = "default",
+    configuration_name: str,
     base_path: str = DEFAULT_BASE_PATH,
 ) -> str:
     """Execute a datpackage and return execution logs"""
-    # Get execution container name from the argument space
-    container_name = load_argument_space(
-        algorithm_name, argument_space_name, base_path
-    )["container"]
+    # Get execution container name from the configuration
+    container_name = load_configuration(configuration_name, base_path)[
+        "container"
+    ]
 
     return execute_container(
         docker_client=docker_client,
         container_name=container_name,
         environment={
-            "ALGORITHM": algorithm_name,
-            "ARGUMENT_SPACE": argument_space_name,
+            "CONFIGURATION": configuration_name,
         },
         base_path=base_path,
     )
@@ -126,41 +124,36 @@ def load_view(
         return json.load(f)
 
 
-def load_argument_space(
-    algorithm_name: str,
-    argument_space_name: str = "default",
+def load_configuration(
+    configuration_name: str,
     base_path: str = DEFAULT_BASE_PATH,
 ) -> dict:
-    """Load an argument space"""
+    """Load an algorithm configuration"""
     with open(
-        (
-            f"{base_path}/{ARGUMENTS_DIR}/{algorithm_name}."
-            f"{argument_space_name}.json"
-        ),
-        "r",
+        f"{base_path}/{CONFIGURATIONS_DIR}/{configuration_name}.json", "r"
     ) as f:
         return json.load(f)
 
 
-def write_argument_space(
-    argument_space: dict,
+def write_configuration(
+    configuration: dict,
     base_path: str = DEFAULT_BASE_PATH,
 ) -> dict:
-    """Write an argument space"""
+    """Write an algorithm configuration"""
     with open(
-        f"{base_path}/{ARGUMENTS_DIR}/{argument_space['name']}.json",
+        f"{base_path}/{CONFIGURATIONS_DIR}/{configuration['name']}.json",
         "w",
     ) as f:
-        json.dump(argument_space, f, indent=2)
+        json.dump(configuration, f, indent=2)
 
 
 def load_resource(
     resource_name: str,
-    metaschema_name: str | None = None,
+    format_name: str | None = None,
     base_path: str = DEFAULT_BASE_PATH,
 ) -> TabularDataResource | dict:
-    """Load a resource with the specified metaschema"""
-    # Load resource with metaschema
+    """Load a resource with the specified format"""
+    # Load resource with format
     resource_path = f"{base_path}/{RESOURCES_DIR}/{resource_name}.json"
 
     resource = None
@@ -169,29 +162,27 @@ def load_resource(
         # Load resource object
         resource_json = json.load(resource_file)
 
-        if metaschema_name is not None:
-            # Load metaschema into resource object
+        if format_name is not None:
+            # Load format into resource object
             with open(
-                f"{base_path}/{METASCHEMAS_DIR}/{metaschema_name}.json", "r"
-            ) as metaschema_file:
-                resource_json["metaschema"] = json.load(metaschema_file)[
-                    "schema"
-                ]
+                f"{base_path}/{FORMATS_DIR}/{format_name}.json", "r"
+            ) as format_file:
+                resource_json["format"] = json.load(format_file)["schema"]
 
-            # Copy metaschema to resource schema if specified
+            # Copy format to resource schema if specified
             if resource_json["schema"] == "inherit-from-format":
-                # Copy metaschema to schema
-                resource_json["schema"] = resource_json["metaschema"]
-                # Label schema as metaschema copy so we don't overwrite it
-                # when writing back to resource
-                resource_json["schema"]["type"] = "metaschema"
+                # Copy format to schema
+                resource_json["schema"] = resource_json["format"]
+                # Label schema as format copy so we don't overwrite it when
+                # writing back to resource
+                resource_json["schema"]["type"] = "format"
         else:
             # TODO: Temporary mostly harmless hack in order to be able
             # to load resource data into views, where we don't know or care
-            # about the metaschema
-            # Longer-term we should deal with this by handling empty
-            # metaschemas in TabularDataResources, but this will do for now
-            resource_json["metaschema"] = {"hello": "world"}
+            # about the format
+            # Longer-term we should deal with this by handling empty formats
+            # in TabularDataResources, but this will do for now
+            resource_json["format"] = {"hello": "world"}
 
         if (
             resource_json["profile"] == "tabular-data-resource"
@@ -207,31 +198,28 @@ def load_resource(
     return resource
 
 
-def load_resource_by_argument(
-    algorithm_name: str,
-    argument_name: str,
-    argument_space_name: str,
+def load_resource_by_variable(
+    variable_name: str,
+    configuration_name: str,
     base_path: str,
 ) -> TabularDataResource:
-    """Convenience function for loading resource associated with argument"""
-    # Load argument object to get resource and metaschema names
-    argument_space = load_argument_space(
-        algorithm_name, argument_space_name, base_path=base_path
-    )
+    """Convenience function for loading resource associated with a variable"""
+    # Load configuration to get resource and format names
+    configuration = load_configuration(configuration_name, base_path=base_path)
 
-    argument = find_by_name(argument_space["data"], argument_name)
+    variable = find_by_name(configuration["data"], variable_name)
 
-    if argument is None:
+    if variable is None:
         raise KeyError(
             (
-                f"Can't find argument named {argument_name} in argument "
-                f"space {argument_space_name}"
+                f"Can't find variable named {variable_name} in configuration "
+                f"{configuration_name}"
             )
         )
 
     return load_resource(
-        resource_name=argument["resource"],
-        metaschema_name=argument["metaschema"],
+        resource_name=variable["resource"],
+        format_name=variable["format"],
         base_path=base_path,
     )
 
@@ -248,12 +236,13 @@ def write_resource(
 
     resource_path = f"{base_path}/{RESOURCES_DIR}/{resource_json['name']}.json"
 
-    # Remove metaschema before writing
-    # This should have been loaded by load_argument
-    resource_json.pop("metaschema")
+    # Remove format before writing
+    # This should have been loaded by load_resource
+    resource_json.pop("format")
 
-    if resource_json["schema"].get("type") == "metaschema":
-        resource_json["schema"] = "metaschema"  # Don't write metaschema copy
+    if resource_json["schema"].get("type") == "format":
+        # Don't write format copy to schema
+        resource_json["schema"] = "inherit-from-format"
 
     with open(resource_path, "w") as f:
         json.dump(resource_json, f, indent=2)


### PR DESCRIPTION
Rename datapackage directories and some resource keys for clarity.

### Directories
- `pages` -> `interfaces`
- `arguments` -> `configurations`
- `metaschemas` -> `formats`

### Keys
- `algorithm.json: interface` -> `signature`
- `params resources: "schema": "metaschema"` -> `"schema": "inherit-from-format"`
